### PR TITLE
mdt-34486: Remove duplicate settings.local.php include.

### DIFF
--- a/assets/drupal10/settings.php
+++ b/assets/drupal10/settings.php
@@ -10,8 +10,4 @@ $site = 'default';
 // Include site specific settings.
 require DRUPAL_ROOT . "/sites/$site/settings/settings.main.php";
 
-if (file_exists(DRUPAL_ROOT . "/sites/$site/settings/settings.local.php")) {
-  include DRUPAL_ROOT . "/sites/$site/settings/settings.local.php";
-}
-
 /* Drupal installation will put hash salt here. Remove it manually. */


### PR DESCRIPTION
Local settings is already included here: assets/drupal10/settings.main.php:118.

https://github.com/morpht/mdt/blob/main/assets/drupal10/settings.main.php#L118